### PR TITLE
Renamed the ConductR scope to Bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin will take any package that you have presently configured and wrap it 
 
 ## Usage
 
-In addition to declaring the `sbt-native-packager`, declare the plugin (typically in a `plugins.sbt`):
+Declare the plugin (typically in a `plugins.sbt`):
 
 ```scala
 addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % "0.5.0")
@@ -20,6 +20,22 @@ Declaring the native packager or any of its other plugins should be sufficient. 
 
 ```scala
 lazy val root = (project in file(".")).enablePlugins(SbtNativePackager)
+```
+
+_Note that if you have used a pre 1.0 version of sbt-native-packager then you must remove imports such as the following from your `.sbt` files:_
+
+
+```
+import com.typesafe.sbt.SbtNativePackager._
+import NativePackagerKeys._
+```
+
+_...otherwise you will get duplicate imports reported. This is because the new 1.0+ version uses sbt's auto plugin feature._
+
+Finally, produce a bundle:
+
+```
+bundle:dist
 ```
 
 ## Typesafe ConductR Bundles

--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -49,7 +49,7 @@ object Import {
     )
   }
 
-  val ConductR = config("conductr") extend Universal
+  val Bundle = config("bundle") extend Universal
 }
 
 object SbtBundle extends AutoPlugin {
@@ -77,22 +77,22 @@ object SbtBundle extends AutoPlugin {
     bundleType := Universal,
     startCommand := Seq((file("bin") / (executableScriptName in Universal).value).getPath),
     endpoints := Map("web" -> Endpoint("http", 9000)),
-    NativePackagerKeys.dist in ConductR := Def.taskDyn {
+    NativePackagerKeys.dist in Bundle := Def.taskDyn {
       Def.task {
         createDist(bundleType.value)
       }.value
     }.value,
-    NativePackagerKeys.stage in ConductR := Def.taskDyn {
+    NativePackagerKeys.stage in Bundle := Def.taskDyn {
       Def.task {
         stageBundle(bundleType.value)
       }.value
     }.value,
-    NativePackagerKeys.stagingDirectory in ConductR := (target in ConductR).value / "stage",
-    target in ConductR := target.value / "typesafe-conductr"
+    NativePackagerKeys.stagingDirectory in Bundle := (target in Bundle).value / "stage",
+    target in Bundle := target.value / "typesafe-conductr"
   )
 
   private def createDist(bundleTypeConfig: Configuration): Def.Initialize[Task[File]] = Def.task {
-    val bundleTarget = (target in ConductR).value
+    val bundleTarget = (target in Bundle).value
     val configTarget = bundleTarget / "tmp"
     def relParent(p: (File, String)): (File, String) =
       (p._1, (packageName in Universal).value + java.io.File.separator + p._2)
@@ -157,7 +157,7 @@ object SbtBundle extends AutoPlugin {
   }
 
   private def stageBundle(bundleTypeConfig: Configuration): Def.Initialize[Task[File]] = Def.task {
-    val bundleTarget = (NativePackagerKeys.stagingDirectory in ConductR).value
+    val bundleTarget = (NativePackagerKeys.stagingDirectory in Bundle).value
     writeConfig(bundleTarget, bundleConf.value)
     val componentTarget = bundleTarget / (packageName in Universal).value
     IO.copy((mappings in bundleTypeConfig).value.map(p => (p._1, componentTarget / p._2)))

--- a/src/sbt-test/sbt-bundle/basic/test
+++ b/src/sbt-test/sbt-bundle/basic/test
@@ -1,3 +1,3 @@
-> conductr:dist
+> bundle:dist
 
 > checkBundleConf


### PR DESCRIPTION
I did this because:

* it clashed with the `conductr` command of the `sbt-typesafe-conductr` plugin; and
* because it also relates more directly to the `sbt-bundle` plugin.

In addition the doco has been enhanced as a result of some user feedback (Ed).