### PR TITLE
Scheduling requirements are back to bundle.conf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.0.0-5f0e74fcdfa43d9d654e590694bddef526fd94ac")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.0.0-RC1")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/sbt-bundle-tester/build.sbt
+++ b/sbt-bundle-tester/build.sbt
@@ -3,3 +3,8 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 name := "simple-test"
 
 version := "0.1.0-SNAPSHOT"
+
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := "64m"
+BundleKeys.diskSpace := "10m"
+BundleKeys.roles := Set("web-server")

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -7,6 +7,11 @@ name := "simple-test"
 
 version := "0.1.0-SNAPSHOT"
 
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := "64m"
+BundleKeys.diskSpace := "10m"
+BundleKeys.roles := Set("web-server")
+
 BundleKeys.endpoints := Map(
   "web" -> Endpoint("http", 0, 9000, "/simple-test"),
   "other" -> Endpoint("http", 0, 9001, "/simple-test")
@@ -17,11 +22,16 @@ val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 checkBundleConf := {
   val contents = IO.read(target.value / "typesafe-conductr" / "tmp" / "bundle.conf")
   val expectedContents = """|version    = "1.0.0"
+                            |system     = "simple-test-0.1.0-SNAPSHOT"
+                            |nrOfCpus   = 1.0
+                            |memory     = 67108864
+                            |diskSpace  = 10485760
+                            |roles      = ["web-server"]
                             |components = {
                             |  "simple-test-0.1.0-SNAPSHOT" = {
                             |    description      = "simple-test"
                             |    file-system-type = "universal"
-                            |    start-command    = ["simple-test-0.1.0-SNAPSHOT/bin/simple-test"]
+                            |    start-command    = ["simple-test-0.1.0-SNAPSHOT/bin/simple-test", "-Xmm=67108864", "-Xmx=67108864"]
                             |    endpoints        = {
                             |      "web" = {
                             |        protocol     = "http"


### PR DESCRIPTION
The scheduling requirements are now back to `bundle.conf` as they are a developer concern, not an operator's. In addition the memory declaration is applied to a bundle component's mx and mm parameters, otherwise sbt-native-packager will insist that these values should be 1GB. 1GB is excessive for running lots of small things on ConductR.

Also updated to the latest sbt-native-packager (`1.0.0-RC1`).