### PR TITLE
Service URIs instead of a single service name and port

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,8 @@ sbtPlugin := true
 organization := "com.typesafe.sbt"
 name := "sbt-bundle"
 
+libraryDependencies += "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-M4"
+
 scalaVersion := "2.10.4"
 scalacOptions ++= List(
   "-unchecked",
@@ -21,7 +23,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.0.0-RC1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -1,5 +1,7 @@
-import org.scalatest.Matchers._
 import ByteConversions._
+import com.typesafe.sbt.bundle.SbtBundle._
+import akka.http.model.Uri
+import org.scalatest.Matchers._
 
 lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 
@@ -13,8 +15,8 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
 BundleKeys.endpoints := Map(
-  "web" -> Endpoint("http", 0, 9000, "/simple-test"),
-  "other" -> Endpoint("http", 0, 9001, "/simple-test")
+  "web" -> Endpoint("http", 0, Set(Uri("http://:9000/simple-test"))),
+  "other" -> Endpoint("http", 0, Set(Uri("http://:9001/simple-test")))
 )
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
@@ -34,16 +36,14 @@ checkBundleConf := {
                             |    start-command    = ["simple-test-0.1.0-SNAPSHOT/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
                             |    endpoints        = {
                             |      "web" = {
-                            |        protocol     = "http"
-                            |        bind-port    = 0
-                            |        service-port = 9000
-                            |        service-name = "/simple-test"
+                            |        protocol  = "http"
+                            |        bind-port = 0
+                            |        services  = ["http://:9000/simple-test"]
                             |      },
                             |      "other" = {
-                            |        protocol     = "http"
-                            |        bind-port    = 0
-                            |        service-port = 9001
-                            |        service-name = "/simple-test"
+                            |        protocol  = "http"
+                            |        bind-port = 0
+                            |        services  = ["http://:9001/simple-test"]
                             |      }
                             |    }
                             |  }


### PR DESCRIPTION
This needs to be aligned with https://github.com/typesafehub/typesafe-conductr/pull/482, i.e. once that PR got merged, this one needs to be merged, releases of this project and sbt-typesafe-conductr created, etc.