### PR TITLE
Removed akka.http.Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ When your component will run within a container you may alternatively declare th
 
 The service port is the port on which your service will be addressed to the outside world on. Extending last example, if port 80 is to be used to provide your services and then the following expression can be used to resolve `/myservice` on:
 
-    BundleKeys.endpoints := Map("web" -> Endpoint("http", 9000, Set(Uri("http:/myservice"))))
+    BundleKeys.endpoints := Map("web" -> Endpoint("http", 9000, Set(URI("http:/myservice"))))
 
 ## Settings
 

--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -1,6 +1,5 @@
 package com.typesafe.sbt.bundle
 
-import akka.http.model.Uri
 import com.typesafe.sbt.SbtNativePackager
 import com.typesafe.sbt.packager.universal.Archives
 import java.io.{ FileInputStream, BufferedInputStream }
@@ -14,7 +13,7 @@ import scala.annotation.tailrec
 
 object Import {
 
-  case class Endpoint(protocol: String, bindPort: Int, services: Set[Uri])
+  case class Endpoint(protocol: String, bindPort: Int, services: Set[URI])
 
   object BundleKeys {
 
@@ -94,6 +93,11 @@ object Import {
     }
   }
 
+  object URI {
+    def apply(uri: String): URI =
+      new sbt.URI(uri)
+  }
+
   val Bundle = config("bundle") extend Universal
 }
 
@@ -124,7 +128,7 @@ object SbtBundle extends AutoPlugin {
       s"-J-Xms${memory.value.round1k.underlying}",
       s"-J-Xmx${memory.value.round1k.underlying}"
     ),
-    endpoints := Map("web" -> Endpoint("http", 0, Set(Uri(s"http://:9000/${name.value}")))),
+    endpoints := Map("web" -> Endpoint("http", 0, Set(URI(s"http://:9000/${name.value}")))),
     NativePackagerKeys.dist in Bundle := Def.taskDyn {
       Def.task {
         createDist(bundleType.value)

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -15,8 +15,8 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
 BundleKeys.endpoints := Map(
-  "web" -> Endpoint("http", 0, Set(Uri("http://:9000/simple-test"))),
-  "other" -> Endpoint("http", 0, Set(Uri("http://:9001/simple-test")))
+  "web" -> Endpoint("http", 0, Set(URI("http://:9000/simple-test"))),
+  "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
 )
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")


### PR DESCRIPTION
...so that we don't expose our internals. Using the sbt URI type instead.

Fixes #27 