### PR TITLE
Removes the use of a service name by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Bundles provide Typesafe ConductR with some basic knowledge about components in 
 ([Typesafe configuration](https://github.com/typesafehub/config) is used):
 
 ```
-version = "1.0.0"
+version    = "1.0.0"
+name       = "simple-test"
 system     = "simple-test-0.1.0-SNAPSHOT"
 nrOfCpus   = 1.0
 memory     = 67108864
@@ -67,7 +68,7 @@ components = {
       "angular-seed-play" = {
         protocol  = "http"
         bind-port = 0
-        services  = ["http:/angular-seed-play"]
+        services  = ["http://:9000"]
       }
     }
   }
@@ -120,9 +121,9 @@ When your component will run within a container you may alternatively declare th
 
 ### Service ports
 
-The service port is the port on which your service will be addressed to the outside world on. Extending last example, if port 80 is to be used to provide your services and then the following expression can be used to resolve `/myservice` on:
+The service port is the port on which your service will be addressed to the outside world on. For example, if port 80 is to be used to provide your services and then the following expression can be used to resolve `/myservice` on:
 
-    BundleKeys.endpoints := Map("web" -> Endpoint("http", 9000, Set(URI("http:/myservice"))))
+    BundleKeys.endpoints := Map("web" -> Endpoint("http", 0, Set(URI("http:/myservice"))))
 
 ## Settings
 

--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -128,7 +128,7 @@ object SbtBundle extends AutoPlugin {
       s"-J-Xms${memory.value.round1k.underlying}",
       s"-J-Xmx${memory.value.round1k.underlying}"
     ),
-    endpoints := Map("web" -> Endpoint("http", 0, Set(URI(s"http://:9000/${name.value}")))),
+    endpoints := Map("web" -> Endpoint("http", 0, Set(URI(s"http://:9000")))),
     NativePackagerKeys.dist in Bundle := Def.taskDyn {
       Def.task {
         createDist(bundleType.value)
@@ -197,6 +197,7 @@ object SbtBundle extends AutoPlugin {
 
   private def getConfig: Def.Initialize[Task[String]] = Def.task {
     s"""|version    = "1.0.0"
+        |name       = "${name.value}"
         |system     = "${system.value}"
         |nrOfCpus   = ${nrOfCpus.value}
         |memory     = ${memory.value.underlying}

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -14,16 +14,14 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
-BundleKeys.endpoints := Map(
-  "web" -> Endpoint("http", 0, Set(URI("http://:9000/simple-test"))),
-  "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
-)
+BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
 checkBundleConf := {
   val contents = IO.read(target.value / "typesafe-conductr" / "tmp" / "bundle.conf")
   val expectedContents = """|version    = "1.0.0"
+                            |name       = "simple-test"
                             |system     = "simple-test-0.1.0-SNAPSHOT"
                             |nrOfCpus   = 1.0
                             |memory     = 67108864
@@ -38,7 +36,7 @@ checkBundleConf := {
                             |      "web" = {
                             |        protocol  = "http"
                             |        bind-port = 0
-                            |        services  = ["http://:9000/simple-test"]
+                            |        services  = ["http://:9000"]
                             |      },
                             |      "other" = {
                             |        protocol  = "http"


### PR DESCRIPTION
Also re-instates the "name" property so that the CLI can derive the name initially.

Fixes #29 
