### PR TITLE
Various tidying up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-jdk: openjdk6
+jdk: openjdk7
 language: scala
 script: sbt scripted

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Typesafe ConductR Bundle Plugin
+# ConductR Bundle Plugin
 
 [![Build Status](https://api.travis-ci.org/sbt/sbt-bundle.png?branch=master)](https://travis-ci.org/sbt/sbt-bundle)
 
@@ -44,11 +44,11 @@ Finally, produce a bundle:
 bundle:dist
 ```
 
-## Typesafe ConductR Bundles
+## ConductR Bundles
 
-Typesafe ConductR has a bundle format in order for components to be described. In general there is a one-to-one correlation between a bundle and a component.
+ConductR has a bundle format in order for components to be described. In general there is a one-to-one correlation between a bundle and a component.
 
-Bundles provide Typesafe ConductR with some basic knowledge about components in a *bundle descriptor*; in particular, what is required in order to load and run a component. The following is an example of a `bundle.conf` descriptor:
+Bundles provide ConductR with some basic knowledge about components in a *bundle descriptor*; in particular, what is required in order to load and run a component. The following is an example of a `bundle.conf` descriptor:
 ([Typesafe configuration](https://github.com/typesafehub/config) is used):
 
 ```
@@ -105,7 +105,7 @@ service-name | A name to be used to address the service. In the case of http pro
 host-port    | This is not declared but is dynamically allocated if bundle is running in a container. Otherwise it has the same value as bind-port.
 bind-port    | The port the bundle component’s application or service actually binds to. When this is 0 it will be dynamically allocated (which is the default).
 
-Endpoints are declared using an `endpoint` setting using a Map of endpoint-name/`Endpoint(protocol, bindPort, services)` pairs.
+Endpoints are declared using an `endpoint` setting using a Map of endpoint-name/`Endpoint(bindProtocol, bindPort, services)` pairs.
 
 The bind-port allocated to your bundle will be available as an environment variable to your component. For example, given the default settings where an endpoint named "web" is declared that has a dynamically allocated port, an environment variable named `WEB_BIND_PORT` will become available. `WEB_BIND_IP` is also available and should be used as the interface to bind to.  
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,12 @@ sbtPlugin := true
 organization := "com.typesafe.sbt"
 name := "sbt-bundle"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-M5"
-
 scalaVersion := "2.10.4"
 scalacOptions ++= List(
   "-unchecked",
   "-deprecation",
   "-language:_",
-  "-target:jvm-1.6",
+  "-target:jvm-1.7",
   "-encoding", "UTF-8"
 )
 
@@ -24,7 +22,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -146,7 +146,7 @@ object SbtBundle extends AutoPlugin {
       }.value
     }.value,
     NativePackagerKeys.stagingDirectory in Bundle := (target in Bundle).value / "stage",
-    target in Bundle := target.value / "typesafe-conductr"
+    target in Bundle := target.value / "bundle"
   )
 
   private def createDist(bundleTypeConfig: Configuration): Def.Initialize[Task[File]] = Def.task {
@@ -165,6 +165,7 @@ object SbtBundle extends AutoPlugin {
     val hashName = archiveName.take(exti) + "-" + hash + archiveName.drop(exti)
     val hashArchive = archive.getParentFile / hashName
     IO.move(archive, hashArchive)
+    streams.value.log.info(s"Bundle has been created: $hashArchive")
     hashArchive
   }
 

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -1,6 +1,5 @@
 import ByteConversions._
 import com.typesafe.sbt.bundle.SbtBundle._
-import akka.http.model.Uri
 import org.scalatest.Matchers._
 
 lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
@@ -19,7 +18,7 @@ BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/sim
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
 checkBundleConf := {
-  val contents = IO.read(target.value / "typesafe-conductr" / "tmp" / "bundle.conf")
+  val contents = IO.read(target.value / "bundle" / "tmp" / "bundle.conf")
   val expectedContents = """|version    = "1.0.0"
                             |name       = "simple-test"
                             |system     = "simple-test-0.1.0-SNAPSHOT"


### PR DESCRIPTION
Includes:
* Updating to the final native packager and reflecting its JDK requirement
* Removed an unneeded dependency on akka-http
* Dropped the "Typesafe" from references to ConductR given branding requirements
* Changed the target folder for creating bundles to just "bundle" as this is more direct

Fixes #39 
Also fixes #1 (finally!)
