### PR TITLE
Services were incorrectly formatted

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -197,7 +197,7 @@ object SbtBundle extends AutoPlugin {
       } yield s"""|      "$label" = {
                   |        bind-protocol  = "$bindProtocol"
                   |        bind-port = $bindPort
-                  |        services  = [${services.mkString("\"", "\", \"", "\"")}]
+                  |        services  = ${formatSeq(services.map(_.toString))}
                   |      }""".stripMargin
     formatted.mkString(f"{%n", f",%n", f"%n    }")
   }

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -14,6 +14,7 @@ BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
 BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
+BundleKeys.endpoints += "akka-remote" -> Endpoint("tcp")
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
@@ -41,6 +42,11 @@ checkBundleConf := {
                             |        bind-protocol  = "http"
                             |        bind-port = 0
                             |        services  = ["http://:9001/simple-test"]
+                            |      },
+                            |      "akka-remote" = {
+                            |        bind-protocol  = "tcp"
+                            |        bind-port = 0
+                            |        services  = []
                             |      }
                             |    }
                             |  }


### PR DESCRIPTION
Previously, an empty service would result in a string of `[""]`. Empty services are common when specifying the `akka-remote` endpoint.