### PR TITLE
Principally changed the source dir of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ in build.sbt
 Then to produce this additional bundle:
 
 ```
-config:dist
+configuration:dist
 ```
 
 ## Settings

--- a/sbt-bundle-tester/build.sbt
+++ b/sbt-bundle-tester/build.sbt
@@ -11,4 +11,4 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
-configurationName := "frontend"
+BundleKeys.configurationName := "frontend"

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -18,7 +18,7 @@ BundleKeys.endpoints += "akka-remote" -> Endpoint("tcp")
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
-configurationName := "backend"
+BundleKeys.configurationName := "backend"
 
 checkBundleConf := {
   val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")

--- a/src/sbt-test/sbt-bundle/bundleConfig/build.sbt
+++ b/src/sbt-test/sbt-bundle/bundleConfig/build.sbt
@@ -15,7 +15,7 @@ BundleKeys.roles := Set("web-server")
 
 val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
-configurationName := "backend"
+BundleKeys.configurationName := "backend"
 
 val checkConfigDist = taskKey[Unit]("check-config-dist-contents")
 

--- a/src/sbt-test/sbt-bundle/bundleConfig/test
+++ b/src/sbt-test/sbt-bundle/bundleConfig/test
@@ -1,3 +1,3 @@
-> config:dist
+> configuration:dist
 
 > checkConfigDist


### PR DESCRIPTION
The source directory of configuration is now lined up with universal:sourceDirectory. This means that Play applications will see the location of configuration where it is expected (under the base directory).

Some other tidy-ups also occurred.