### PR TITLE
Add examples for startCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ memory            | The amount of memory required to run the bundle.
 nrOfCpus          | The number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). Required.
 roles             | The types of node in the cluster that this bundle can be deployed to. Defaults to having no specific roles.
 system            | A logical name that can be used to associate multiple bundles with each other. This could be an application or service association and should include a version e.g. myapp-1.0.0. Defaults to the package name.
-startCommand      | Command line args required to start the component. Paths are expressed relative to the component's bin folder. The default is to use the bash script in the bin folder.
+startCommand   | Command line args required to start the component. Paths are expressed relative to the component's bin folder. The default is to use the bash script in the bin folder. <br/> Example JVM component: </br> `BundleKeys.startCommand += "-Xms126m -Xmx512m"` </br> Example Docker component: </br> `BundleKeys.startCommand += "dockerArgs -v /var/lib/postgresql/data:/var/lib/postgresql/data"`
 checks            | Declares uris to check to signal to ConductR that the bundle components have started for situations where a component doesn't do that. For example Seq("$WEB_HOST") will check that a endpoint named "web" will be checked given its host environment var. Once that URL becomes available then ConductR will be signalled that the bundle is ready.
 configurationName | The name of the directory of the additional configuration to use. Defaults to 'default'
 


### PR DESCRIPTION
Add examples for startCommand incl. an example with `dockerArgs`.