### PR TITLE
Introduced a compatibility version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A plugin that uses the [sbt-native-packager](https://github.com/sbt/sbt-native-packager) to produce Typesafe ConductR bundles.
 
-The plugin will take any package that you have presently configured and wrap it in a bundle.
+The plugin will take a Universal or Docker package that you have presently configured and wrap it in a bundle.
 
 ## Usage
 
@@ -53,9 +53,7 @@ bundle:dist
 ```
 
 It is possible to produce additional configuration bundles that contain an optional bundle.conf the value of which override the main bundle, as
-well as arbitrary shell scripts.
-
-These additional configuration files must be placed in <src>/bundle-configuration/<configurationFolderName>.
+well as arbitrary shell scripts. These additional configuration files must be placed in <src>/bundle-configuration/<configurationFolderName>.
 
 The bundle-configuration folder may contain many configurations, the desired configuration can be specified with the setting:
 
@@ -63,31 +61,44 @@ The bundle-configuration folder may contain many configurations, the desired con
 BundleKeys.configurationName := <configurationFolderName>
 ```
 
-in build.sbt
+...in build.sbt
 
-Then to produce this additional bundle:
+Then, to produce this additional bundle:
 
 ```
 configuration:dist
 ```
 
+## ConductR 1.0
+
+ConductR 1.0 did not hold the notion of a `compatibilityVersion` or a `systemVersion`. Instead, sbt-bundle 1.0 encoded these versions into
+a bundle's `name` and the `system` name `bundle.conf` properties. Therefore if you use sbt-bundle 1.1 with ConductR 1.0 then you may
+want to encode these versions within your build file. This can be conveniently achieved easily using the following expression:
+
+```scala
+normalizedName in Bundle := (NativePackagerKeys.packageName in Bundle).value
+```
+
+
 ## Settings
 
 The following settings are provided under the `BundleKeys` object:
 
-Name              | Description
-------------------|-------------
-bundleConf        | The bundle configuration file contents.
-bundleType        | The type of configuration that this bundling relates to. By default Universal is used.
-diskSpace         | The amount of disk space required to host an expanded bundle and configuration. Append the letter k or K to indicate kilobytes, or m or M to indicate megabytes. Required.
-endpoints         | Declares endpoints using an `Endpoint(protocol, bindPort, services)` structure. The default is `Map("web" -> Endpoint("http", services = Set(URI(s"http://:9000"))))` where the key is the `name` of this project. The "web" key is used to form a set of environment variables for your components. For example you will have a `WEB_BIND_PORT` in this example.
-memory            | The amount of memory required to run the bundle.
-nrOfCpus          | The number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). Required.
-roles             | The types of node in the cluster that this bundle can be deployed to. Defaults to having no specific roles.
-system            | A logical name that can be used to associate multiple bundles with each other. This could be an application or service association and should include a version e.g. myapp-1.0.0. Defaults to the package name.
-startCommand      | Command line args required to start the component. Paths are expressed relative to the component's bin folder. The default is to use the bash script in the bin folder. <br/> Example JVM component: </br> `BundleKeys.startCommand += "-Dhttp.address=$WEB_BIND_IP -Dhttp.port=$WEB_BIND_PORT"` </br> Example Docker component: </br> `BundleKeys.startCommand += "dockerArgs -v /var/lib/postgresql/data:/var/lib/postgresql/data"` (this adds arguments to `docker run`). Note that memory heap is controlled by the memory BundleKey and heap flags should not be passed here.
-checkInitialDelay | Initial delay before the check uris are triggered. The `FiniteDuration` value gets rounded up to full seconds. Default is 3 seconds.
-checks            | Declares uris to check to signal to ConductR that the bundle components have started for situations where component doesn't do that. For example Seq(uri("$WEB_HOST?retry-count=5&retry-delay=2")) will check that a endpoint named "web" will be checked given its host environment var. Once that URL becomes available then ConductR will be signalled that the bundle is ready. Optional params are: 'retry-count': Number of retries, 'retry-delay': Delay in seconds between retries, 'docker-timeout': Timeout in seconds for docker container start.
-configurationName | The name of the directory of the additional configuration to use. Defaults to 'default'
+Name                 | Description
+---------------------|-------------
+bundleConf           | The bundle configuration file contents.
+bundleType           | The type of configuration that this bundling relates to. By default Universal is used.
+checkInitialDelay    | Initial delay before the check uris are triggered. The `FiniteDuration` value gets rounded up to full seconds. Default is 3 seconds.
+checks               | Declares uris to check to signal to ConductR that the bundle components have started for situations where component doesn't do that. For example Seq(uri("$WEB_HOST?retry-count=5&retry-delay=2")) will check that a endpoint named "web" will be checked given its host environment var. Once that URL becomes available then ConductR will be signalled that the bundle is ready. Optional params are: 'retry-count': Number of retries, 'retry-delay': Delay in seconds between retries, 'docker-timeout': Timeout in seconds for docker container start.
+compatibilityVersion | A versioning scheme that will be included in a bundle's name that describes the level of compatibility with bundles that go before it. By default we take the major version component of a version as defined by [http://semver.org/]. However you can make this mean anything that you need it to mean in relation to bundles produced prior to it. We take the notion of a compatibility version from [http://ometer.com/parallel.html]."
+configurationName    | The name of the directory of the additional configuration to use. Defaults to 'default'
+diskSpace            | The amount of disk space required to host an expanded bundle and configuration. Append the letter k or K to indicate kilobytes, or m or M to indicate megabytes. Required.
+endpoints            | Declares endpoints using an `Endpoint(protocol, bindPort, services)` structure. The default is `Map("web" -> Endpoint("http", services = Set(URI(s"http://:9000"))))` where the key is the `name` of this project. The "web" key is used to form a set of environment variables for your components. For example you will have a `WEB_BIND_PORT` in this example.
+memory               | The amount of memory required to run the bundle.
+nrOfCpus             | The number of cpus required to run the bundle (can be fractions thereby expressing a portion of CPU). Required.
+roles                | The types of node in the cluster that this bundle can be deployed to. Defaults to "web".
+startCommand         | Command line args required to start the component. Paths are expressed relative to the component's bin folder. The default is to use the bash script in the bin folder. <br/> Example JVM component: </br> `BundleKeys.startCommand += "-Dhttp.address=$WEB_BIND_IP -Dhttp.port=$WEB_BIND_PORT"` </br> Example Docker component: </br> `BundleKeys.startCommand += "dockerArgs -v /var/lib/postgresql/data:/var/lib/postgresql/data"` (this adds arguments to `docker run`). Note that memory heap is controlled by the memory BundleKey and heap flags should not be passed here.
+system               | A logical name that can be used to associate multiple bundles with each other. This could be an application or service association and should include a version e.g. myapp-1.0.0. Defaults to the package name.
+systemVersion        | A version to associate with a system. This setting defaults to the value of compatibilityVersion.
 
 &copy; Typesafe Inc., 2014-2015

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -22,18 +22,20 @@ BundleKeys.configurationName := "backend"
 
 checkBundleConf := {
   val contents = IO.read((target in Bundle).value / "tmp" / "bundle.conf")
-  val expectedContents = """|version    = "1.0.0"
-                            |name       = "simple-test"
-                            |system     = "simple-test-0.1.0-SNAPSHOT"
-                            |nrOfCpus   = 1.0
-                            |memory     = 67108864
-                            |diskSpace  = 10000000
-                            |roles      = ["web-server"]
+  val expectedContents = """|version              = "1.1.0"
+                            |name                 = "simple-test"
+                            |compatibilityVersion = "0"
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 1.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web-server"]
                             |components = {
-                            |  "simple-test-0.1.0-SNAPSHOT" = {
+                            |  "simple-test" = {
                             |    description      = "simple-test"
                             |    file-system-type = "universal"
-                            |    start-command    = ["simple-test-0.1.0-SNAPSHOT/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
+                            |    start-command    = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
                             |    endpoints        = {
                             |      "web" = {
                             |        bind-protocol  = "http"

--- a/src/sbt-test/sbt-bundle/checks/build.sbt
+++ b/src/sbt-test/sbt-bundle/checks/build.sbt
@@ -12,7 +12,6 @@ version := "0.1.0-SNAPSHOT"
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
-BundleKeys.roles := Set("web-server")
 BundleKeys.checkInitialDelay := 1400.milliseconds
 BundleKeys.checks := Seq(uri("$WEB_HOST?retry-count=5&retry-delay=3"))
 
@@ -20,18 +19,20 @@ val checkBundleConf = taskKey[Unit]("check-main-css-contents")
 
 checkBundleConf := {
   val contents = IO.read(target.value / "bundle" / "tmp" / "bundle.conf")
-  val expectedContents = """|version    = "1.0.0"
-                            |name       = "simple-test"
-                            |system     = "simple-test-0.1.0-SNAPSHOT"
-                            |nrOfCpus   = 1.0
-                            |memory     = 67108864
-                            |diskSpace  = 10000000
-                            |roles      = ["web-server"]
+  val expectedContents = """|version              = "1.1.0"
+                            |name                 = "simple-test"
+                            |compatibilityVersion = "0"
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 1.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web"]
                             |components = {
-                            |  "simple-test-0.1.0-SNAPSHOT" = {
+                            |  "simple-test" = {
                             |    description      = "simple-test"
                             |    file-system-type = "universal"
-                            |    start-command    = ["simple-test-0.1.0-SNAPSHOT/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
+                            |    start-command    = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
                             |    endpoints        = {
                             |      "web" = {
                             |        bind-protocol  = "http"
@@ -40,7 +41,7 @@ checkBundleConf := {
                             |      }
                             |    }
                             |  },
-                            |  "simple-test-0.1.0-SNAPSHOT-status" = {
+                            |  "simple-test-status" = {
                             |    description      = "Status check for the bundle component"
                             |    file-system-type = "universal"
                             |    start-command    = ["check", "--initial-delay", "2", "$WEB_HOST?retry-count=5&retry-delay=3"]


### PR DESCRIPTION
A versioning scheme that will be included in a bundle's name that describes the level of compatibility with bundles that go before it. By default we take the major version component of a version as defined by http://semver.org/. However you can make this mean anything that you need it to mean in relation to bundles produced prior to it. We take the notion of a compatibility version from http://ometer.com/parallel.html.