### PR TITLE
Prettify output

### DIFF
--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -20,33 +20,37 @@ val checkBundleConf = taskKey[Unit]("")
 
 checkBundleConf := {
   val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
-  val expectedContents = """|version = "1.1.0"
-                            |name = "simple-test"
+  val expectedContents = """|version              = "1.1.0"
+                            |name                 = "simple-test"
                             |compatibilityVersion = "0"
-                            |system = "simple-test"
-                            |systemVersion = "0"
-                            |nrOfCpus = 1.0
-                            |memory = 67108864
-                            |diskSpace = 10000000
-                            |roles = ["web-server"]
-                            |components."simple-test".description = "simple-test"
-                            |components."simple-test"."file-system-type" = "universal"
-                            |components."simple-test"."start-command" = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
-                            |components."simple-test".endpoints = {
-                            |  "web" = {
-                            |    bind-protocol  = "http"
-                            |    bind-port = 0
-                            |    services  = ["http://:9000"]
-                            |  },
-                            |  "other" = {
-                            |    bind-protocol  = "http"
-                            |    bind-port = 0
-                            |    services  = ["http://:9001/simple-test"]
-                            |  },
-                            |  "akka-remote" = {
-                            |    bind-protocol  = "tcp"
-                            |    bind-port = 0
-                            |    services  = []
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 1.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web-server"]
+                            |components = {
+                            |  simple-test = {
+                            |    description      = "simple-test"
+                            |    file-system-type = "universal"
+                            |    start-command    = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
+                            |    endpoints = {
+                            |      "web" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        services      = ["http://:9000"]
+                            |      },
+                            |      "other" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        services      = ["http://:9001/simple-test"]
+                            |      },
+                            |      "akka-remote" = {
+                            |        bind-protocol = "tcp"
+                            |        bind-port     = 0
+                            |        services      = []
+                            |      }
+                            |    }
                             |  }
                             |}""".stripMargin
   contents should include(expectedContents)

--- a/src/sbt-test/sbt-bundle/checks/build.sbt
+++ b/src/sbt-test/sbt-bundle/checks/build.sbt
@@ -19,30 +19,36 @@ val checkBundleConf = taskKey[Unit]("")
 
 checkBundleConf := {
   val contents = IO.read(target.value / "bundle" / "bundle" / "tmp" / "bundle.conf")
-  val expectedContents = """|version = "1.1.0"
-                            |name = "simple-test"
+  val expectedContents = """|version              = "1.1.0"
+                            |name                 = "simple-test"
                             |compatibilityVersion = "0"
-                            |system = "simple-test"
-                            |systemVersion = "0"
-                            |nrOfCpus = 1.0
-                            |memory = 67108864
-                            |diskSpace = 10000000
-                            |roles = ["web"]
-                            |components."simple-test".description = "simple-test"
-                            |components."simple-test"."file-system-type" = "universal"
-                            |components."simple-test"."start-command" = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
-                            |components."simple-test".endpoints = {
-                            |  "web" = {
-                            |    bind-protocol  = "http"
-                            |    bind-port = 0
-                            |    services  = ["http://:9000"]
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 1.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web"]
+                            |components = {
+                            |  simple-test = {
+                            |    description      = "simple-test"
+                            |    file-system-type = "universal"
+                            |    start-command    = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
+                            |    endpoints = {
+                            |      "web" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        services      = ["http://:9000"]
+                            |      }
+                            |    }
                             |  }
                             |}
-                            |components."simple-test-status" = {
-                            |  description      = "Status check for the bundle component"
-                            |  file-system-type = "universal"
-                            |  start-command    = ["check", "--initial-delay", "2", "$WEB_HOST?retry-count=5&retry-delay=3"]
-                            |  endpoints        = {}
+                            |components = {
+                            |  simple-test-status = {
+                            |    description      = "Status check for the bundle component"
+                            |    file-system-type = "universal"
+                            |    start-command    = ["check", "--initial-delay", "2", "$WEB_HOST?retry-count=5&retry-delay=3"]
+                            |    endpoints        = {}
+                            |  }
                             |}""".stripMargin
   contents should include(expectedContents)
 }

--- a/src/sbt-test/sbt-bundle/overlays/build.sbt
+++ b/src/sbt-test/sbt-bundle/overlays/build.sbt
@@ -33,23 +33,27 @@ val checkBundleConf = taskKey[Unit]("")
 
 checkBundleConf := {
   val contents = IO.read((target in Backend).value / "backend" / "tmp" / "bundle.conf")
-  val expectedContents = """|version = "1.1.0"
-                            |name = "simple-test"
+  val expectedContents = """|version              = "1.1.0"
+                            |name                 = "simple-test"
                             |compatibilityVersion = "0"
-                            |system = "simple-test"
-                            |systemVersion = "0"
-                            |nrOfCpus = 2.0
-                            |memory = 67108864
-                            |diskSpace = 10000000
-                            |roles = ["web"]
-                            |components."simple-test".description = "simple-test"
-                            |components."simple-test"."file-system-type" = "universal"
-                            |components."simple-test"."start-command" = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
-                            |components."simple-test".endpoints = {
-                            |  "web" = {
-                            |    bind-protocol  = "http"
-                            |    bind-port = 0
-                            |    services  = ["http://:9000"]
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 2.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web"]
+                            |components = {
+                            |  simple-test = {
+                            |    description      = "simple-test"
+                            |    file-system-type = "universal"
+                            |    start-command    = ["simple-test/bin/simple-test", "-J-Xms67108864", "-J-Xmx67108864"]
+                            |    endpoints = {
+                            |      "web" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        services      = ["http://:9000"]
+                            |      }
+                            |    }
                             |  }
                             |}""".stripMargin
   contents should include(expectedContents)
@@ -59,6 +63,11 @@ val checkBundleConfigConf = taskKey[Unit]("")
 
 checkBundleConfigConf := {
   val contents = IO.read((target in BackendConfiguration).value / "stage" / "backend-config" / "bundle.conf")
-  val expectedContents = "nrOfCpus = 12.0"
+  val expectedContents =
+    """nrOfCpus             = 12.0
+      |components = {
+      |  simple-test = {
+      |  }
+      |}""".stripMargin
   contents should include(expectedContents)
 }


### PR DESCRIPTION
The output is once again prettified given that python's phocon library could not parse the advanced path form that Typesafe Config permits.