### PR TITLE
Handle Bundle conf versioning

### DIFF
--- a/src/sbt-test/sbt-bundle/aclServicesValidation/build.sbt
+++ b/src/sbt-test/sbt-bundle/aclServicesValidation/build.sbt
@@ -1,0 +1,45 @@
+import ByteConversions._
+import com.typesafe.sbt.bundle.SbtBundle._
+import org.scalatest.Matchers._
+
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
+
+name := "acl-services-validation-test"
+
+version := "0.1.0-SNAPSHOT"
+
+BundleKeys.bundleConfVersion := BundleConfVersions.V_1_2_0
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 10.MB
+BundleKeys.roles := Set("web-server")
+
+BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
+BundleKeys.endpoints += "akka-remote" -> Endpoint("tcp")
+BundleKeys.endpoints += "extras" -> Endpoint("http", 0, Some(Set(URI("http://:9001/simple-test"))), Some("ping-service"),
+  Some(
+    Set(
+      RequestAcl(
+        Http(
+          "/bar-1",
+          "GET" -> "/bar-2",
+          "GET" -> "/bar-3" -> "/other-bar-3",
+          "^/beg-1".r,
+          "GET" -> "^/beg-2".r,
+          "GET" -> "^/beg-3".r -> "/other-beg-3",
+          "/regex1/[a|b|c]".r,
+          "GET" -> "/regex2/[a|b|c]".r,
+          "GET" -> "/regex3/[a|b|c]".r -> "/other-regex-3"
+        )),
+      RequestAcl(Tcp(9001, 9002)),
+      RequestAcl(Udp(19001, 19002))
+    )
+  )
+)
+
+val checkBundleConfNotGenerated = taskKey[Unit]("")
+
+checkBundleConfNotGenerated := {
+  val bundleConfFile = (target in Bundle).value / "bundle" / "tmp" / "bundle.conf"
+  bundleConfFile.exists() shouldBe false
+}

--- a/src/sbt-test/sbt-bundle/aclServicesValidation/project/build.properties
+++ b/src/sbt-test/sbt-bundle/aclServicesValidation/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-bundle/aclServicesValidation/project/plugins.sbt
+++ b/src/sbt-test/sbt-bundle/aclServicesValidation/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-bundle/aclServicesValidation/test
+++ b/src/sbt-test/sbt-bundle/aclServicesValidation/test
@@ -1,0 +1,3 @@
+-> bundle:dist
+
+> checkBundleConfNotGenerated

--- a/src/sbt-test/sbt-bundle/aclValidation/build.sbt
+++ b/src/sbt-test/sbt-bundle/aclValidation/build.sbt
@@ -1,0 +1,40 @@
+import ByteConversions._
+import com.typesafe.sbt.bundle.SbtBundle._
+import org.scalatest.Matchers._
+
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
+
+name := "acl-validation-test"
+
+version := "0.1.0-SNAPSHOT"
+
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 10.MB
+BundleKeys.roles := Set("web-server")
+
+BundleKeys.endpoints += "other" -> Endpoint("http", 0, Set(URI("http://:9001/simple-test")))
+BundleKeys.endpoints += "akka-remote" -> Endpoint("tcp")
+BundleKeys.endpoints += "extras" -> Endpoint("http", 0, "ping-service",
+  RequestAcl(
+    Http(
+      "/bar-1",
+      "GET" -> "/bar-2",
+      "GET" -> "/bar-3" -> "/other-bar-3",
+      "^/beg-1".r,
+      "GET" -> "^/beg-2".r,
+      "GET" -> "^/beg-3".r -> "/other-beg-3",
+      "/regex1/[a|b|c]".r,
+      "GET" -> "/regex2/[a|b|c]".r,
+      "GET" -> "/regex3/[a|b|c]".r -> "/other-regex-3"
+    )),
+  RequestAcl(Tcp(9001, 9002)),
+  RequestAcl(Udp(19001, 19002))
+)
+
+val checkBundleConfNotGenerated = taskKey[Unit]("")
+
+checkBundleConfNotGenerated := {
+  val bundleConfFile = (target in Bundle).value / "bundle" / "tmp" / "bundle.conf"
+  bundleConfFile.exists() shouldBe false
+}

--- a/src/sbt-test/sbt-bundle/aclValidation/project/build.properties
+++ b/src/sbt-test/sbt-bundle/aclValidation/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-bundle/aclValidation/project/plugins.sbt
+++ b/src/sbt-test/sbt-bundle/aclValidation/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-bundle/aclValidation/test
+++ b/src/sbt-test/sbt-bundle/aclValidation/test
@@ -1,0 +1,3 @@
+-> bundle:dist
+
+> checkBundleConfNotGenerated

--- a/src/sbt-test/sbt-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bundle/basic/build.sbt
@@ -7,6 +7,7 @@ lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
 name := "simple-test"
 
 version := "0.1.0-SNAPSHOT"
+BundleKeys.bundleConfVersion := BundleConfVersions.V_1_2_0
 
 BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
@@ -36,7 +37,7 @@ val checkBundleConf = taskKey[Unit]("")
 
 checkBundleConf := {
   val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
-  val expectedContents = """|version              = "1.1.0"
+  val expectedContents = """|version              = "1.2.0"
                             |name                 = "simple-test"
                             |compatibilityVersion = "0"
                             |system               = "simple-test"


### PR DESCRIPTION
* Remove deprecation warning on the services
* Introduce setting key for specifying bundle.conf version
* Prevent ACLs to be used unless bundle.conf version is 1.2.0

Addresses #61 