### PR TITLE
Collect configuration files in sub directories

### DIFF
--- a/src/test/scala/com/typesafe/sbt/bundle/SbtBundleSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/bundle/SbtBundleSpec.scala
@@ -1,6 +1,8 @@
 package com.typesafe.sbt.bundle
 
 import org.scalatest.{ Matchers, WordSpec }
+import sbt.IO
+import java.io.File
 
 class SbtBundleSpec extends WordSpec with Matchers {
   "SbtBundle.PathMatching.pathConfigKeyValue" should {
@@ -37,4 +39,72 @@ class SbtBundleSpec extends WordSpec with Matchers {
           }
       }
   }
+
+  "SbtBundle.recursiveListFiles" should {
+
+    import SbtBundle._
+
+    "list files in single directory" in {
+      withTemporaryDirectory { dir =>
+        val bundleConf = new File(s"$dir/bundle.conf")
+        bundleConf.createNewFile()
+        val runtimeConfig = new File(s"$dir/runtime-config.sh")
+        runtimeConfig.createNewFile()
+
+        val expectedFiles = Array(bundleConf, runtimeConfig)
+
+        recursiveListFiles(Array(dir), NonDirectoryFilter).sorted shouldBe expectedFiles.sorted
+      }
+    }
+
+    "list files in one sub directory" in {
+      withTemporaryDirectory { dir =>
+        val bundleConf = new File(s"$dir/bundle.conf")
+        bundleConf.createNewFile()
+        val runtimeConfig = new File(s"$dir/runtime-config.sh")
+        runtimeConfig.createNewFile()
+        val subDir = new File(s"$dir/conf")
+        subDir.mkdir()
+        val subFile = new File(s"$subDir/logback.xml")
+        subFile.createNewFile()
+
+        val expectedFiles = Array(bundleConf, runtimeConfig, subFile)
+
+        recursiveListFiles(Array(dir), NonDirectoryFilter).sorted shouldBe expectedFiles.sorted
+      }
+    }
+
+    "list files in multiple sub directories" in {
+      withTemporaryDirectory { dir =>
+        val bundleConf = new File(s"$dir/bundle.conf")
+        bundleConf.createNewFile()
+        val runtimeConfig = new File(s"$dir/runtime-config.sh")
+        runtimeConfig.createNewFile()
+        val subDir1 = new File(s"$dir/conf")
+        subDir1.mkdir()
+        val subDir1File = new File(s"$subDir1/logback.xml")
+        subDir1File.createNewFile()
+        val subDir2 = new File(s"$dir/logs")
+        subDir2.mkdir()
+        val subDir2File1 = new File(s"$subDir2/application.log")
+        subDir2File1.createNewFile()
+        val subDir2File2 = new File(s"$subDir2/system.log")
+        subDir2File2.createNewFile()
+
+        val expectedFiles = Array(bundleConf, runtimeConfig, subDir1File, subDir2File1, subDir2File2).sorted
+
+        recursiveListFiles(Array(dir), NonDirectoryFilter).sorted shouldBe expectedFiles.sorted
+      }
+    }
+  }
+
+  private def withTemporaryDirectory[T](body: => File => T): T = {
+    val tempDir = IO.createTemporaryDirectory
+    try {
+      body(tempDir)
+    } finally {
+      tempDir.delete()
+    }
+  }
+
 }


### PR DESCRIPTION
When bundle configuration has one or more subdirectory, now `configuration:dist` includes the files in the sub directories to the zip file as well.

Fixes PR https://github.com/sbt/sbt-bundle/issues/60. 