### PR TITLE
Replace backslash in BundleKeys.startCommand

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/SbtBundle.scala
@@ -688,7 +688,12 @@ object SbtBundle extends AutoPlugin {
     def toString[T](valueAndConfigName: (T, Option[String]), f: T => String): (String, Option[String]) =
       f(valueAndConfigName._1) -> valueAndConfigName._2
 
-    val componentPrefix = s"""components."${(normalizedName in config).value}""""
+    def escapeStartCommand(startCommand: Seq[String]): String = {
+      val executable = startCommand.head
+      val arguments = startCommand.tail
+      val executableEscaped = executable.replace("\\", "/")
+      formatSeq(Seq(executableEscaped) ++ arguments)
+    }
 
     val declarations =
       Seq(s"""version              = "${bundleConfVersion.value}"""") ++
@@ -703,7 +708,7 @@ object SbtBundle extends AutoPlugin {
         Seq("components = {", s"  ${(normalizedName in config).value} = {") ++
         formatValue(s"""    description      = "%s"""", toString((projectInfoConfigName in config).value, (v: ModuleInfo) => v.description)) ++
         formatValue(s"""    file-system-type = "%s"""", (bundleTypeConfigName in config).value) ++
-        formatValue(s"""    start-command    = %s""", toString((startCommandConfigName in config).value, (v: Seq[String]) => formatSeq(v))) ++
+        formatValue(s"""    start-command    = %s""", toString((startCommandConfigName in config).value, (v: Seq[String]) => escapeStartCommand(v))) ++
         formatValue(s"""    endpoints = %s""", toString((endpointsConfigName in config).value, (v: Map[String, Endpoint]) => formatEndpoints(bundleConfVersion.value, v))) ++
         Seq("  }", "}") ++
         checkComponents

--- a/src/sbt-test/sbt-bundle/escapeStartCommand/build.sbt
+++ b/src/sbt-test/sbt-bundle/escapeStartCommand/build.sbt
@@ -1,0 +1,48 @@
+import ByteConversions._
+import com.typesafe.sbt.bundle.SbtBundle._
+import org.scalatest.Matchers._
+import com.typesafe.config.ConfigFactory
+
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
+
+name := "simple-test"
+
+version := "0.1.0-SNAPSHOT"
+BundleKeys.bundleConfVersion := BundleConfVersions.V_1_2_0
+
+BundleKeys.nrOfCpus := 1.0
+BundleKeys.memory := 64.MiB
+BundleKeys.diskSpace := 10.MB
+BundleKeys.startCommand := Seq("this\\is\\my\\start-command", "with", "arguments")
+
+val checkBundleConf = taskKey[Unit]("")
+
+checkBundleConf := {
+  val contents = IO.read((target in Bundle).value / "bundle" / "tmp" / "bundle.conf")
+  // Content should be parseable into Typesafe Config
+  ConfigFactory.parseString(contents)
+  val expectedContents = """|version              = "1.2.0"
+                            |name                 = "simple-test"
+                            |compatibilityVersion = "0"
+                            |system               = "simple-test"
+                            |systemVersion        = "0"
+                            |nrOfCpus             = 1.0
+                            |memory               = 67108864
+                            |diskSpace            = 10000000
+                            |roles                = ["web"]
+                            |components = {
+                            |  simple-test = {
+                            |    description      = "simple-test"
+                            |    file-system-type = "universal"
+                            |    start-command    = ["this/is/my/start-command", "with", "arguments"]
+                            |    endpoints = {
+                            |      "web" = {
+                            |        bind-protocol = "http"
+                            |        bind-port     = 0
+                            |        services      = ["http://:9000"]
+                            |      }
+                            |    }
+                            |  }
+                            |}""".stripMargin
+  contents should include(expectedContents)
+}

--- a/src/sbt-test/sbt-bundle/escapeStartCommand/project/build.properties
+++ b/src/sbt-test/sbt-bundle/escapeStartCommand/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-bundle/escapeStartCommand/project/plugins.sbt
+++ b/src/sbt-test/sbt-bundle/escapeStartCommand/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-bundle" % sys.props("project.version"))
+libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"
+libraryDependencies += "com.typesafe"  %  "config"    % "1.2.1"

--- a/src/sbt-test/sbt-bundle/escapeStartCommand/test
+++ b/src/sbt-test/sbt-bundle/escapeStartCommand/test
@@ -1,0 +1,3 @@
+> bundle:dist
+
+> checkBundleConf


### PR DESCRIPTION
By default `BundleKeys.startCommand` is derived from the paths constructed within sbt. Should the project is run on Windows, BundleKeys.startCommand path will have Windows file separator `\`.

With this file separator, the start command will resolve to invalid path on platforms other than Windows. The start command will resolve correctly to all platforms if the `\` is replaced with `/`.
